### PR TITLE
Add 'and' and 'or' operators

### DIFF
--- a/src/evaluate/expression.js
+++ b/src/evaluate/expression.js
@@ -225,8 +225,9 @@ function applyBinaryOperation (operator, x, y) {
     case '>': return x > y ? 1 : 0
     case '<=': return x <= y ? 1 : 0
     case '<': return x < y ? 1 : 0
-    case 'and': return x && y ? 1 : 0
-    case 'or': return x || y ? 1 : 0
+    case ' and ': return x && y ? 1 : 0
+    case ' or ': return x || y ? 1 : 0
+    case ' xor ': return (!x && y) || (x && !y) ? 1:0
     default: throw core.libError('unexpected binary operator')
   }
 }

--- a/src/evaluate/expression.js
+++ b/src/evaluate/expression.js
@@ -225,6 +225,8 @@ function applyBinaryOperation (operator, x, y) {
     case '>': return x > y ? 1 : 0
     case '<=': return x <= y ? 1 : 0
     case '<': return x < y ? 1 : 0
+    case 'and': return x && y ? 1 : 0
+    case 'or': return x || y ? 1 : 0
     default: throw core.libError('unexpected binary operator')
   }
 }

--- a/src/parse/pegutil.js
+++ b/src/parse/pegutil.js
@@ -3,17 +3,6 @@
 
 import * as types from '../common/types'
 
-export function buildLogicalExpression (head, tail) {
-  return tail.reduce(function (result, element) {
-
-    return {
-      type: types.BINARY,
-      operator: element[1],
-      left: result,
-      right: element[3]
-    }
-  }, head)
-}
 export function buildBinaryExpression (head, tail) {
   return tail.reduce(function (result, element) {
 

--- a/src/parse/pegutil.js
+++ b/src/parse/pegutil.js
@@ -3,8 +3,21 @@
 
 import * as types from '../common/types'
 
+export function buildLogicalExpression (head, tail) {
+  console.log(head, tail)
+  return tail.reduce(function (result, element) {
+
+    return {
+      type: types.BINARY,
+      operator: element[1],
+      left: result,
+      right: element[3]
+    }
+  }, head)
+}
 export function buildBinaryExpression (head, tail) {
   return tail.reduce(function (result, element) {
+
     return {
       type: types.BINARY,
       operator: element[0],
@@ -15,6 +28,7 @@ export function buildBinaryExpression (head, tail) {
 }
 
 export function buildImplicitBinaryExpression (head, tail, end) {
+  
   const list = tail.flat()
   if (end !== null) {
     list.push(end)

--- a/src/parse/pegutil.js
+++ b/src/parse/pegutil.js
@@ -4,7 +4,6 @@
 import * as types from '../common/types'
 
 export function buildLogicalExpression (head, tail) {
-  console.log(head, tail)
   return tail.reduce(function (result, element) {
 
     return {

--- a/src/parse/tibasic.pegjs
+++ b/src/parse/tibasic.pegjs
@@ -222,8 +222,18 @@ TestExpression
   tail:(TestOperator AdditiveExpression)* 
   { return util.buildBinaryExpression(head, tail); }
 
+LogicalOperator
+  = 'and' 
+  / 'or'
+
+LogicalExpression
+  = head:TestExpression
+  tail:( _ LogicalOperator _ TestExpression)* 
+  { return util.buildLogicalExpression(head, tail); }
+
 ValueExpression
-  = TestExpression
+  = LogicalExpression
+
 
 ArgumentExpression
   = ',' @ValueExpression
@@ -233,6 +243,8 @@ PrefixArgumentExpression
 
 ExtraArguments
   = ArgumentExpression+ { return true }
+
+
 
 // ----- Statements -----
 
@@ -430,3 +442,6 @@ Statement
   / CtlStatement
   / IoStatement
   / ValueStatement
+  
+  _ "whitespace"
+  = [ \t\n\r]*

--- a/src/parse/tibasic.pegjs
+++ b/src/parse/tibasic.pegjs
@@ -223,13 +223,14 @@ TestExpression
   { return util.buildBinaryExpression(head, tail); }
 
 LogicalOperator
-  = 'and' 
-  / 'or'
+  = ' and ' 
+  / ' or '
+  / ' xor '
 
 LogicalExpression
   = head:TestExpression
-  tail:( _ LogicalOperator _ TestExpression)* 
-  { return util.buildLogicalExpression(head, tail); }
+  tail:(LogicalOperator TestExpression)* 
+  { return util.buildBinaryExpression(head, tail); }
 
 ValueExpression
   = LogicalExpression
@@ -442,6 +443,3 @@ Statement
   / CtlStatement
   / IoStatement
   / ValueStatement
-  
-  _ "whitespace"
-  = [ \t\n\r]*

--- a/web/js/testCases.js
+++ b/web/js/testCases.js
@@ -308,6 +308,69 @@ const tiJsTests =
         `
     },
     {
+      name: 'And',
+      input: `\
+        Disp 1 and 1
+        Disp 1 and 0
+        Disp 0 and 0
+        Disp 1-1 and 1
+        Disp 1*0 and 1
+        Disp 1 and 1+2
+        Disp 1=1 and 2<3
+        `,
+      expected: `\
+        1
+        0
+        0
+        0
+        0
+        1
+        1
+        `
+    },
+    {
+      name: 'Or',
+      input: `\
+        Disp 1 or 1
+        Disp 1 or 0
+        Disp 0 or 0
+        Disp 1-1 or 1
+        Disp 1*0 or 1
+        Disp 1 or 1+2
+        Disp 1<0 or 2>3
+        `,
+      expected: `\
+        1
+        1
+        0
+        1
+        1
+        1
+        0
+        `
+    },
+    {
+      name: 'Xor',
+      input: `\
+        Disp 1 xor 1
+        Disp 1 xor 0
+        Disp 0 xor 0
+        Disp 1-1 xor 1
+        Disp 1*0 xor 1
+        Disp 1 xor 1+2
+        Disp 1<0 xor 2>3
+        `,
+      expected: `\
+        0
+        1
+        0
+        1
+        1
+        0
+        0
+        `
+    },
+    {
       name: 'Parenthesis',
       input: 'Disp (2)',
       expected: '2'


### PR DESCRIPTION
-And and Or logical operators added. No tests yet, but as of now they adhere to the behavior described by the wiki.
-Whitespace support added. In parser, use '_' to denote a space. This allows for the syntax of logical operators to be used accurately ('expression _ operator _ expression')
```JS
//Parser syntax

...head: Expression 
tail: (_ LogicalOperator _ Expression)...

//TI-BASIC Code
1<2 and 2>1
//Evaluates to 1 (true)
```